### PR TITLE
Change key from ID to UID

### DIFF
--- a/src/fields/SitesField.php
+++ b/src/fields/SitesField.php
@@ -198,7 +198,7 @@ class SitesField extends Field implements PreviewableFieldInterface
 	{
 		$sites = [];
 		foreach (Craft::$app->getSites()->getAllSites() as $site) {
-			$sites[$site->id] = Craft::t('site', $site->name);
+			$sites[$site->uid] = Craft::t('site', $site->name);
 		}
 		return $sites;
 	}


### PR DESCRIPTION
The site id is DB data. It would be preferable to not reference identifiers managed by the DB in the project.yaml config file because this creates the possibility of referencing data that does not exist or that is different (a different DB may associate a different site id with the same logical site depending on creation order). This is not really a problem when there is only one DB, but in situations where there is separate test site DBs or local dev DBs it is best to keep a distinction between config that is shared in the code repos and data in the DB.

The project.yaml file references sites by the site uid, so it would be better to store that as part of the field config instead.

This will be a breaking change for existing users of the plugin, current users will have to reconfigure each field type to set the whitelisted sites again, since the id and uid will not match, and will have to migrate user site stored data to match the uids instead of the id.

This issue is related to: https://github.com/eastslopestudio/craft3-sites-field/issues/8